### PR TITLE
aarch64 kernel (raspi3)

### DIFF
--- a/.github/workflows/xtask.yml
+++ b/.github/workflows/xtask.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo xtask build
+      run: cargo xtask build --verbose
     - name: Run tests
-      run: cargo xtask test
+      run: cargo xtask test --verbose
 
   build-aarch64:
     runs-on: ubuntu-latest
@@ -29,6 +29,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo xtask build
+      run: cargo xtask build --verbose
     - name: Run tests
-      run: cargo xtask test
+      run: cargo xtask test --verbose

--- a/.github/workflows/xtask.yml
+++ b/.github/workflows/xtask.yml
@@ -30,5 +30,5 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo xtask build --verbose
-    - name: Run tests
-      run: cargo xtask test --verbose
+    # - name: Run tests
+    #   run: cargo xtask test --verbose

--- a/.github/workflows/xtask.yml
+++ b/.github/workflows/xtask.yml
@@ -10,9 +10,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  build-x86_64:
     runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo xtask build
+    - name: Run tests
+      run: cargo xtask test
+
+  build-aarch64:
+    runs-on: ubuntu-latest
+    env:
+      ARCH: aarch64
+      TARGET: aarch64-unknown-none-elf
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/xtask.yml
+++ b/.github/workflows/xtask.yml
@@ -30,5 +30,3 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo xtask build --verbose
-    # - name: Run tests
-    #   run: cargo xtask test --verbose

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "custom",
+            "name": "Debug QEMU (aarch64)",
+            "targetCreateCommands": [
+                "target create ${workspaceFolder}/target/aarch64-unknown-none-elf/debug/aarch64"
+            ],
+            "processCreateCommands": [
+                "gdb-remote localhost:1234"
+            ]
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,14 @@
 version = 3
 
 [[package]]
+name = "aarch64"
+version = "0.1.0"
+dependencies = [
+ "bitstruct",
+ "port",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "aarch64",
     "x86_64",
     "port",
     "xtask"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ There are other useful `xtask` subcommands; run
 
 Right now, r9 is not self-hosting.
 
+### Aarch64
+By default, the x86_64 architecture is built and run.  To run the
+xtask commands for the aarch64 architecture, prepend with
+`ARCH=aarch64 TARGET=aarch64-unknown-none-elf`.  E.g. to build and
+run in qemu simulating a Raspberry Pi 3, run:
+`ARCH=aarch64 TARGET=aarch64-unknown-none-elf cargo xtask qemu`.
+
 ## Runtime Dependencies
 
 `cargo xtask dist`, which `cargo xtask qemu` and 
@@ -29,6 +36,6 @@ then install `llvm` separate from the rust toolchain and set:
 OBJCOPY=$(which llvm-objcopy) cargo xtask qemukvm
 ```
 
-if `No such file or directory (os error 2)` messages persist, 
+If `No such file or directory (os error 2)` messages persist, 
 check to ensure `qemu` or `qemu-kvm` is installed and the 
-`qemu-system-x86_64` binary is in your path.
+`qemu-system-x86_64` binary is in your path (or `qemu-system-aarch64` in the case of aarch64).

--- a/aarch64/Cargo.toml
+++ b/aarch64/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "aarch64"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bitstruct = "0.1"
+port = { path = "../port" }

--- a/aarch64/src/devcons.rs
+++ b/aarch64/src/devcons.rs
@@ -244,9 +244,7 @@ impl Uart for Pl011Uart {
 }
 
 pub fn init() {
-    static mut UART: Pl011Uart = Pl011Uart {
-        mmiobase: MMIO_BASE_BCM2837,
-    };
+    static mut UART: Pl011Uart = Pl011Uart { mmiobase: MMIO_BASE_BCM2837 };
     unsafe {
         UART.init();
     };

--- a/aarch64/src/devcons.rs
+++ b/aarch64/src/devcons.rs
@@ -1,0 +1,254 @@
+// Racy to start.
+
+use port::devcons::{Console, Uart};
+
+use core::mem;
+use core::ptr;
+use core::ptr::{read_volatile, write_volatile};
+
+// The aarch64 devcons implementation is focussed on Raspberry Pi 3, 4 for now.
+
+// Useful links
+// - Raspberry Pi Processors
+//     https://www.raspberrypi.com/documentation/computers/processors.html
+// - Raspberry Pi Hardware
+//     https://www.raspberrypi.com/documentation/computers/raspberry-pi.html
+// - Raspi3 BCM2837
+//     Datasheet (BCM2835) https://datasheets.raspberrypi.com/bcm2835/bcm2835-peripherals.pdf
+// - Raspi4 BCM2711
+//     Datasheet https://datasheets.raspberrypi.com/bcm2711/bcm2711-peripherals.pdf
+// - Mailbox
+//     https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
+
+// Raspberry Pi has 4 UARTs:
+// - UART0 PL011
+// - UART1 miniUART
+// - UART2 PL011
+// - UART3 PL011
+// We'll be using the UART0.
+
+// TODO
+// - Detect board type and set MMIO base address accordingly
+//     https://wiki.osdev.org/Detecting_Raspberry_Pi_Board
+// - Break out mailbox, gpio code
+
+const MMIO_BASE_BCM2837: u32 = 0x3f000000;
+//const MMIO_BASE_BCM2711: u32 = 0xfe000000;
+
+const GPIO_BASE: u32 = 0x200000;
+const GPPUD: u32 = GPIO_BASE + 0x94;
+const GPPUDCLK0: u32 = GPIO_BASE + 0x98;
+
+// PL011 UART 0 Registers
+const UART0_BASE: u32 = GPIO_BASE + 0x1000;
+const UART0_DR: u32 = UART0_BASE + 0x00; // Data register
+const UART0_FR: u32 = UART0_BASE + 0x18; // Flag register
+const UART0_IBRD: u32 = UART0_BASE + 0x24; // Integer baud rate divisor
+const UART0_FBRD: u32 = UART0_BASE + 0x28; // Fractional baud rate divisor
+const UART0_LCRH: u32 = UART0_BASE + 0x2c; // Line control register
+const UART0_CR: u32 = UART0_BASE + 0x30; // Control register
+const UART0_IMSC: u32 = UART0_BASE + 0x38; // Interrupt mask set clear register
+const UART0_ICR: u32 = UART0_BASE + 0x44; // Interrupt clear register
+
+const MBOX_BASE: u32 = 0xb880;
+const MBOX_READ: u32 = MBOX_BASE + 0x00;
+const MBOX_STATUS: u32 = MBOX_BASE + 0x18;
+const MBOX_WRITE: u32 = MBOX_BASE + 0x20;
+
+const MBOX_FULL: u32 = 0x80000000;
+const MBOX_EMPTY: u32 = 0x40000000;
+
+// Delay for count cycles
+fn delay(count: u32) {
+    unsafe {
+        core::arch::asm!(
+            "1:",
+            "nop",
+            "subs {count}, {count}, 1",
+            "bne 1b",
+            count = in(reg) count);
+    }
+}
+
+#[repr(u32)]
+enum TagId {
+    GetClockRate = 0x38002,
+}
+
+#[repr(u8)]
+enum ChannelId {
+    ArmToVc = 8,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct SetClockRateRequest {
+    size: u32, // size in bytes
+    code: u32, // request code (0)
+
+    // Tag
+    tag_id0: u32,
+    tag_buffer_size0: u32,
+    tag_code0: u32,
+    clock_id: u32,
+    rate_hz: u32,
+    skip_setting_turbo: u32,
+    // No tag padding
+    end_tag: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct SetClockRateResponse {
+    size: u32, // size in bytes
+    code: u32, // response code
+
+    // Tag
+    tag_id0: u32,
+    tag_buffer_size0: u32,
+    tag_code0: u32,
+    clock_id: u32,
+    rate_hz: u32,
+    // No tag padding
+    end_tag: u32,
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy)]
+union SetClockRate {
+    request: SetClockRateRequest,
+    response: SetClockRateResponse,
+}
+
+impl SetClockRate {
+    pub fn new(clock_id: u32, rate_hz: u32, skip_setting_turbo: u32) -> Self {
+        SetClockRate {
+            request: SetClockRateRequest {
+                size: mem::size_of::<SetClockRateRequest>() as u32,
+                code: 0,
+                tag_id0: TagId::GetClockRate as u32,
+                tag_buffer_size0: 12,
+                tag_code0: 0,
+                clock_id: clock_id,
+                rate_hz: rate_hz,
+                skip_setting_turbo: skip_setting_turbo,
+                end_tag: 0,
+            },
+        }
+    }
+}
+
+enum GpioPull {
+    Off = 0,
+    Down,
+    Up,
+}
+
+struct Pl011Uart {
+    mmiobase: u32,
+}
+
+impl Pl011Uart {
+    pub fn init(&self) {
+        // Disable uart0
+        self.mmiowrite(UART0_CR, 0);
+
+        // Turn pull up/down off for pins 14/15 (tx/rx)
+        self.gpiosetpull(14, GpioPull::Off);
+        self.gpiosetpull(15, GpioPull::Off);
+
+        // Clear interrupts
+        self.mmiowrite(UART0_ICR, 0x7ff);
+
+        // Read status register until full flag not set
+        while (self.mmioread(MBOX_STATUS) & MBOX_FULL) != 0 {}
+
+        // Set the uart clock rate to 3MHz
+        let uart_clock_rate_hz = 3_000_000;
+        let set_clock_rate_req = SetClockRate::new(2, uart_clock_rate_hz, 0);
+        let channel = ChannelId::ArmToVc;
+
+        // Write the request address combined with the channel to the write register
+        let uart_mbox_u32 = ptr::addr_of!(set_clock_rate_req) as u32;
+        let r = (uart_mbox_u32 & !0xF) | (channel as u32);
+        self.mmiowrite(MBOX_WRITE, r);
+
+        // Wait for repsonse
+        loop {
+            while (self.mmioread(MBOX_STATUS) & MBOX_EMPTY) != 0 {}
+            let response = self.mmioread(MBOX_READ);
+            if response == r {
+                break;
+            }
+        }
+
+        // Set the baud rate via the integer and fractional baud rate regs
+        let baud_rate = 115200;
+        let baud_rate_divisor = (uart_clock_rate_hz as f32) / ((16 * baud_rate) as f32);
+        let int_brd = baud_rate_divisor as u32;
+        let frac_brd = (((baud_rate_divisor - (int_brd as f32)) * 64.0) + 0.5) as u32;
+        self.mmiowrite(UART0_IBRD, int_brd);
+        self.mmiowrite(UART0_FBRD, frac_brd);
+
+        // Enable FIFOs (tx and rx), 8 bit
+        self.mmiowrite(UART0_LCRH, 0x70);
+
+        // Mask all interrupts
+        self.mmiowrite(UART0_IMSC, 0x7f2);
+
+        // Enable UART0, receive only
+        self.mmiowrite(UART0_CR, 0x81);
+    }
+
+    fn mmiowrite(&self, reg: u32, val: u32) {
+        let dst = self.mmiobase + reg;
+        unsafe { write_volatile(dst as *mut u32, val) }
+    }
+
+    fn mmioread(&self, reg: u32) -> u32 {
+        let dst = self.mmiobase + reg;
+        unsafe { read_volatile(dst as *const u32) }
+    }
+
+    fn gpiosetpull(&self, pin: u32, pull: GpioPull) {
+        // The GPIO pull up/down bits are spread across consecutive registers GPPUDCLK0 to GPPUDCLK1
+        // GPPUDCLK0: pins  0-31
+        // GPPUDCLK1: pins 32-53
+        let reg_offset = pin / 32;
+        // Number of bits to shift pull, in order to affect the required pin (just 1 bit)
+        let pud_bit = 1 << (pin % 32);
+        let gppud_reg = GPPUD;
+        // Which GPPUDCLK register to use
+        let gppudclk_reg = GPPUDCLK0 + reg_offset * 4;
+
+        // You can't read the GPPUD registers, so to set the state we first set the PUD value we want...
+        self.mmiowrite(gppud_reg, pull as u32);
+        // ...wait 150 cycles for it to set
+        delay(150);
+        // ...set the appropriate PUD bit
+        self.mmiowrite(gppudclk_reg, pud_bit);
+        // ...wait 150 cycles for it to set
+        delay(150);
+        // ...clear up
+        self.mmiowrite(gppud_reg, 0);
+        self.mmiowrite(gppudclk_reg, 0);
+    }
+}
+
+impl Uart for Pl011Uart {
+    fn putb(&self, b: u8) {
+        // Wait for UART to become ready to transmit.
+        while self.mmioread(UART0_FR) & (1 << 5) != 0 {}
+        self.mmiowrite(UART0_DR, b as u32);
+    }
+}
+
+pub fn init() {
+    static mut UART: Pl011Uart = Pl011Uart {
+        mmiobase: MMIO_BASE_BCM2837,
+    };
+    unsafe {
+        UART.init();
+    };
+    Console::new(unsafe { &mut UART });
+}

--- a/aarch64/src/kernel.ld
+++ b/aarch64/src/kernel.ld
@@ -53,7 +53,6 @@ SECTIONS {
 		*(COMMON)
 		. = ALIGN(2097152);
 	}
-	PROVIDE(ebss = .);
 	PROVIDE(end = .);
 
 	/DISCARD/ : {

--- a/aarch64/src/kernel.ld
+++ b/aarch64/src/kernel.ld
@@ -1,0 +1,62 @@
+/*
+ * Linker script for R9.
+ */
+
+ENTRY(start)
+
+SECTIONS {
+	/*
+	 * start the kernel at 0x0xffff_8000_0020_0000
+	 * This preserves some RAM between 1MiB and the
+	 * start of the kernel for critical structures.
+	 */
+	/* . = 0xffff800000100000; */
+
+	. = 0x80000;
+
+	PROVIDE(boottext = .);
+	.text.boot : ALIGN(4096) {
+		*(.boottext .bootdata)
+		. = ALIGN(4096);
+		PROVIDE(eboottext = .);
+		. = ALIGN(2097152);
+		PROVIDE(esys = .);
+	}
+
+	PROVIDE(text = .);
+	.text : ALIGN(4096) {
+		*(.text* .stub .gnu.linkonce.t.*)
+		. = ALIGN(2097152);	
+		PROVIDE(etext = .);
+	}
+
+	.rodata : ALIGN(4096) {
+		*(.rodata* .gnu.linkonce.r.*)
+		. = ALIGN(2097152);
+		PROVIDE(erodata = .);
+	}
+
+	.data : ALIGN(4096) {
+		*(.data*)
+	}
+	.got : ALIGN(4096) {
+		*(.got)
+	}
+	.got.plt : ALIGN(4096) {
+		*(.got.plt)
+	}
+	PROVIDE(edata = .);
+
+	PROVIDE(bss = .);
+	.bss : ALIGN(4096) {
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(2097152);
+	}
+	PROVIDE(ebss = .);
+	PROVIDE(end = .);
+
+	/DISCARD/ : {
+		*(.eh_frame .note.GNU-stack)
+	}
+}

--- a/aarch64/src/l.S
+++ b/aarch64/src/l.S
@@ -16,7 +16,7 @@ start:
 
 	// Clean the BSS section
     ldr     x1, =bss     		// Start address
-    ldr     w2, =ebss  		    // Size of the section
+    ldr     w2, =end  		    // End of bss
 3:  cbz     w2, 4f              // Quit loop if zero
     str     xzr, [x1], #8
     sub     w2, w2, #1

--- a/aarch64/src/l.S
+++ b/aarch64/src/l.S
@@ -10,20 +10,20 @@ start:
 	cbnz    x1, 5f
 	
 	// On the main core, so set up the initial stack
-	ldr		x5, =start
-	add		x5, x5, #4096
-	mov		sp, x5
+	ldr	x5, =start
+	add	x5, x5, #4096
+	mov	sp, x5
 
 	// Clean the BSS section
 	ldr     x1, =bss     		// Start address
-	ldr     w2, =end  		    // End of bss
-3:  cbz     w2, 4f              // Quit loop if zero
+	ldr     w2, =end  		// End of bss
+3:  	cbz     w2, 4f              	// Quit loop if zero
 	str     xzr, [x1], #8
 	sub     w2, w2, #1
-	cbnz    w2, 3b              // Loop if non-zero
+	cbnz    w2, 3b              	// Loop if non-zero
 
-4:	bl main9
+4:	bl	main9
 
 5:
 	wfe
-	b		5b
+	b	5b

--- a/aarch64/src/l.S
+++ b/aarch64/src/l.S
@@ -5,25 +5,24 @@
 
 start:
 	// All cores other than 0 should just hang
-	mrs     x1, mpidr_el1
-	and     x1, x1, #3
-	cbnz    x1, 5f
+	mrs     x0, mpidr_el1
+	and     x0, x0, #0xff
+	cbnz    x0, hang
 	
 	// On the main core, so set up the initial stack
-	ldr	x5, =start
-	add	x5, x5, #4096
-	mov	sp, x5
+	ldr	x0, =start
+	add	x0, x0, #4096
+	mov	sp, x0
 
-	// Clean the BSS section
-	ldr     x1, =bss     		// Start address
-	ldr     w2, =end  		// End of bss
-3:  	cbz     w2, 4f              	// Quit loop if zero
-	str     xzr, [x1], #8
-	sub     w2, w2, #1
-	cbnz    w2, 3b              	// Loop if non-zero
+	// Clear bss
+	ldr     x0, =bss     		// Start address
+	ldr     x1, =end  		// End of bss
+clearbss:
+  	str     xzr, [x0], #8
+	cmp	x0, x1
+	b.ne	clearbss
 
-4:	bl	main9
+	bl	main9
 
-5:
-	wfe
-	b	5b
+hang:	wfe
+	b	hang

--- a/aarch64/src/l.S
+++ b/aarch64/src/l.S
@@ -10,9 +10,9 @@ start:
     cbnz    x1, 5f
 	
 	// On the main core, so set up the initial stack
-	ldr	x5, =start
-	add	x5, x5, #4096
-	mov	sp, x5
+	ldr		x5, =start
+	add		x5, x5, #4096
+	mov		sp, x5
 
 	// Clean the BSS section
     ldr     x1, =bss     		// Start address
@@ -26,4 +26,4 @@ start:
 
 5:
 	wfe
-	b 5b
+	b		5b

--- a/aarch64/src/l.S
+++ b/aarch64/src/l.S
@@ -5,9 +5,9 @@
 
 start:
 	// All cores other than 0 should just hang
-    mrs     x1, mpidr_el1
-    and     x1, x1, #3
-    cbnz    x1, 5f
+	mrs     x1, mpidr_el1
+	and     x1, x1, #3
+	cbnz    x1, 5f
 	
 	// On the main core, so set up the initial stack
 	ldr		x5, =start
@@ -15,12 +15,12 @@ start:
 	mov		sp, x5
 
 	// Clean the BSS section
-    ldr     x1, =bss     		// Start address
-    ldr     w2, =end  		    // End of bss
+	ldr     x1, =bss     		// Start address
+	ldr     w2, =end  		    // End of bss
 3:  cbz     w2, 4f              // Quit loop if zero
-    str     xzr, [x1], #8
-    sub     w2, w2, #1
-    cbnz    w2, 3b              // Loop if non-zero
+	str     xzr, [x1], #8
+	sub     w2, w2, #1
+	cbnz    w2, 3b              // Loop if non-zero
 
 4:	bl main9
 

--- a/aarch64/src/l.S
+++ b/aarch64/src/l.S
@@ -7,7 +7,7 @@ start:
 	// All cores other than 0 should just hang
     mrs     x1, mpidr_el1
     and     x1, x1, #3
-    cbnz    x1, hang
+    cbnz    x1, 5f
 	
 	// On the main core, so set up the initial stack
 	ldr	x5, =start
@@ -24,6 +24,6 @@ start:
 
 4:	bl main9
 
-hang:
+5:
 	wfe
-	b hang
+	b 5b

--- a/aarch64/src/l.S
+++ b/aarch64/src/l.S
@@ -1,0 +1,29 @@
+// Aarch64 entry (Raspberry Pi 3, 4 focussed)
+ 
+.section .boottext, "awx"
+.globl start
+
+start:
+	// All cores other than 0 should just hang
+    mrs     x1, mpidr_el1
+    and     x1, x1, #3
+    cbnz    x1, hang
+	
+	// On the main core, so set up the initial stack
+	ldr	x5, =start
+	add	x5, x5, #4096
+	mov	sp, x5
+
+	// Clean the BSS section
+    ldr     x1, =bss     		// Start address
+    ldr     w2, =ebss  		    // Size of the section
+3:  cbz     w2, 4f              // Quit loop if zero
+    str     xzr, [x1], #8
+    sub     w2, w2, #1
+    cbnz    w2, 3b              // Loop if non-zero
+
+4:	bl main9
+
+hang:
+	wfe
+	b hang

--- a/aarch64/src/main.rs
+++ b/aarch64/src/main.rs
@@ -1,10 +1,10 @@
+#![feature(alloc_error_handler)]
 #![feature(asm_const)]
 #![feature(asm_sym)]
 #![cfg_attr(not(any(test, feature = "cargo-clippy")), no_std)]
 #![cfg_attr(not(test), no_main)]
 #![allow(clippy::upper_case_acronyms)]
 #![forbid(unsafe_op_in_unsafe_fn)]
-#![feature(core_intrinsics, lang_items)]
 
 mod devcons;
 
@@ -22,13 +22,4 @@ pub extern "C" fn main9() {
     loop {}
 }
 
-#[cfg(not(any(test, feature = "cargo-clippy")))]
-mod runtime {
-    use core::panic::PanicInfo;
-
-    #[panic_handler]
-    pub extern "C" fn panic(_info: &PanicInfo) -> ! {
-        #[allow(clippy::empty_loop)]
-        loop {}
-    }
-}
+mod runtime;

--- a/aarch64/src/main.rs
+++ b/aarch64/src/main.rs
@@ -1,0 +1,34 @@
+#![feature(asm_const)]
+#![feature(asm_sym)]
+#![cfg_attr(not(any(test, feature = "cargo-clippy")), no_std)]
+#![cfg_attr(not(test), no_main)]
+#![allow(clippy::upper_case_acronyms)]
+#![forbid(unsafe_op_in_unsafe_fn)]
+#![feature(core_intrinsics, lang_items)]
+
+mod devcons;
+
+core::arch::global_asm!(include_str!("l.S"));
+
+use port::println;
+
+#[no_mangle]
+pub extern "C" fn main9() {
+    devcons::init();
+    println!();
+    println!("r9 from the Internet");
+    println!("looping now");
+    #[allow(clippy::empty_loop)]
+    loop {}
+}
+
+#[cfg(not(any(test, feature = "cargo-clippy")))]
+mod runtime {
+    use core::panic::PanicInfo;
+
+    #[panic_handler]
+    pub extern "C" fn panic(_info: &PanicInfo) -> ! {
+        #[allow(clippy::empty_loop)]
+        loop {}
+    }
+}

--- a/aarch64/src/runtime.rs
+++ b/aarch64/src/runtime.rs
@@ -1,0 +1,31 @@
+#![cfg(not(any(test, feature = "cargo-clippy")))]
+
+extern crate alloc;
+
+use alloc::alloc::{GlobalAlloc, Layout};
+use core::panic::PanicInfo;
+
+#[panic_handler]
+pub extern "C" fn panic(_info: &PanicInfo) -> ! {
+    #[allow(clippy::empty_loop)]
+    loop {}
+}
+
+#[alloc_error_handler]
+fn oom(_layout: Layout) -> ! {
+    panic!("oom");
+}
+
+struct FakeAlloc;
+
+unsafe impl GlobalAlloc for FakeAlloc {
+    unsafe fn alloc(&self, _layout: Layout) -> *mut u8 {
+        panic!("fake alloc");
+    }
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {
+        panic!("fake dealloc");
+    }
+}
+
+#[global_allocator]
+static FAKE_ALLOCATOR: FakeAlloc = FakeAlloc {};

--- a/lib/aarch64-unknown-none-elf.json
+++ b/lib/aarch64-unknown-none-elf.json
@@ -1,0 +1,20 @@
+{
+	"arch": "aarch64",
+	"data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
+	"disable-redzone": true,
+	"executables": true,
+	"features": "+strict-align,+neon,+fp-armv8",
+	"linker": "rust-lld",
+	"linker-flavor": "ld.lld",
+	"llvm-target": "aarch64-unknown-none",
+	"max-atomic-width": 128,
+	"panic-strategy": "abort",
+	"relocation-model": "static",
+	"target-pointer-width": "64",
+	"pre-link-args": {
+		"ld.lld": [
+			"-Taarch64/src/kernel.ld",
+			"-nostdlib"
+		]
+	}
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -36,46 +36,54 @@ fn main() {
         .subcommand(clap::Command::new("build").about("Builds r9").args(&[
             clap::arg!(--release "Build release version").conflicts_with("debug"),
             clap::arg!(--debug "Build debug version (default)").conflicts_with("release"),
+            clap::arg!(--verbose "Print commands"),
         ]))
         .subcommand(clap::Command::new("expand").about("Expands r9 macros").args(&[
             clap::arg!(--release "Build release version").conflicts_with("debug"),
             clap::arg!(--debug "Build debug version (default)").conflicts_with("release"),
+            clap::arg!(--verbose "Print commands"),
         ]))
         .subcommand(clap::Command::new("kasm").about("Emits r9 assembler").args(&[
             clap::arg!(--release "Build release version").conflicts_with("debug"),
             clap::arg!(--debug "Build debug version (default)").conflicts_with("release"),
+            clap::arg!(--verbose "Print commands"),
         ]))
         .subcommand(clap::Command::new("dist").about("Builds a multibootable r9 image").args(&[
             clap::arg!(--release "Build a release version").conflicts_with("debug"),
             clap::arg!(--debug "Build a debug version").conflicts_with("release"),
+            clap::arg!(--verbose "Print commands"),
         ]))
         .subcommand(clap::Command::new("test").about("Runs unit tests").args(&[
             clap::arg!(--release "Build a release version").conflicts_with("debug"),
             clap::arg!(--debug "Build a debug version").conflicts_with("release"),
+            clap::arg!(--verbose "Print commands"),
         ]))
         .subcommand(clap::Command::new("clippy").about("Runs clippy").args(&[
             clap::arg!(--release "Build a release version").conflicts_with("debug"),
             clap::arg!(--debug "Build a debug version").conflicts_with("release"),
+            clap::arg!(--verbose "Print commands"),
         ]))
         .subcommand(clap::Command::new("qemu").about("Run r9 under QEMU").args(&[
             clap::arg!(--release "Build a release version").conflicts_with("debug"),
             clap::arg!(--debug "Build a debug version").conflicts_with("release"),
+            clap::arg!(--verbose "Print commands"),
         ]))
         .subcommand(clap::Command::new("qemukvm").about("Run r9 under QEMU with KVM").args(&[
             clap::arg!(--release "Build a release version").conflicts_with("debug"),
             clap::arg!(--debug "Build a debug version").conflicts_with("release"),
+            clap::arg!(--verbose "Print commands"),
         ]))
         .subcommand(clap::Command::new("clean").about("Cargo clean"))
         .get_matches();
     if let Err(e) = match matches.subcommand() {
-        Some(("build", m)) => build(build_type(m)),
-        Some(("expand", m)) => expand(build_type(m)),
-        Some(("kasm", m)) => kasm(build_type(m)),
-        Some(("dist", m)) => dist(build_type(m)),
-        Some(("test", m)) => test(build_type(m)),
-        Some(("clippy", m)) => clippy(build_type(m)),
-        Some(("qemu", m)) => run(build_type(m)),
-        Some(("qemukvm", m)) => accelrun(build_type(m)),
+        Some(("build", m)) => build(build_type(m), verbose(m)),
+        Some(("expand", m)) => expand(build_type(m), verbose(m)),
+        Some(("kasm", m)) => kasm(build_type(m), verbose(m)),
+        Some(("dist", m)) => dist(build_type(m), verbose(m)),
+        Some(("test", m)) => test(build_type(m), verbose(m)),
+        Some(("clippy", m)) => clippy(build_type(m), verbose(m)),
+        Some(("qemu", m)) => run(build_type(m), verbose(m)),
+        Some(("qemukvm", m)) => accelrun(build_type(m), verbose(m)),
         Some(("clean", _)) => clean(),
         _ => Err("bad subcommand".into()),
     } {
@@ -89,6 +97,10 @@ fn build_type(matches: &clap::ArgMatches) -> Build {
         return Build::Release;
     }
     Build::Debug
+}
+
+fn verbose(matches: &clap::ArgMatches) -> bool {
+    matches.contains_id("verbose")
 }
 
 fn env_or(var: &str, default: &str) -> String {
@@ -135,7 +147,7 @@ fn target() -> String {
     env_or("TARGET", "x86_64-unknown-none-elf")
 }
 
-fn build(profile: Build) -> Result<()> {
+fn build(profile: Build, verbose: bool) -> Result<()> {
     let mut cmd = Command::new(cargo());
     cmd.current_dir(workspace());
     cmd.arg("build");
@@ -146,6 +158,9 @@ fn build(profile: Build) -> Result<()> {
     cmd.arg("--exclude").arg("xtask");
     exclude_other_arches(&mut cmd);
     profile.add_build_arg(&mut cmd);
+    if verbose {
+        println!("Executing {:?}", cmd);
+    }
     let status = cmd.status()?;
     if !status.success() {
         return Err("build kernel failed".into());
@@ -153,7 +168,7 @@ fn build(profile: Build) -> Result<()> {
     Ok(())
 }
 
-fn expand(profile: Build) -> Result<()> {
+fn expand(profile: Build, verbose: bool) -> Result<()> {
     let mut cmd = Command::new(cargo());
     cmd.current_dir(workspace());
     cmd.arg("rustc");
@@ -163,6 +178,9 @@ fn expand(profile: Build) -> Result<()> {
     cmd.arg("--");
     cmd.arg("-Z").arg("unpretty=expanded");
     profile.add_build_arg(&mut cmd);
+    if verbose {
+        println!("Executing {:?}", cmd);
+    }
     let status = cmd.status()?;
     if !status.success() {
         return Err("build kernel failed".into());
@@ -170,7 +188,7 @@ fn expand(profile: Build) -> Result<()> {
     Ok(())
 }
 
-fn kasm(profile: Build) -> Result<()> {
+fn kasm(profile: Build, verbose: bool) -> Result<()> {
     let mut cmd = Command::new(cargo());
     cmd.current_dir(workspace());
     cmd.arg("rustc");
@@ -179,6 +197,9 @@ fn kasm(profile: Build) -> Result<()> {
     cmd.arg("--target").arg(format!("lib/{}.json", target()));
     cmd.arg("--").arg("--emit").arg("asm");
     profile.add_build_arg(&mut cmd);
+    if verbose {
+        println!("Executing {:?}", cmd);
+    }
     let status = cmd.status()?;
     if !status.success() {
         return Err("build kernel failed".into());
@@ -186,8 +207,8 @@ fn kasm(profile: Build) -> Result<()> {
     Ok(())
 }
 
-fn dist(profile: Build) -> Result<()> {
-    build(profile)?;
+fn dist(profile: Build, verbose: bool) -> Result<()> {
+    build(profile, verbose)?;
 
     if arch() == "x86_64" {
         let mut cmd = Command::new(objcopy());
@@ -196,6 +217,9 @@ fn dist(profile: Build) -> Result<()> {
         cmd.arg(format!("target/{}/{}/x86_64", target(), profile.dir()));
         cmd.arg(format!("target/{}/{}/r9.elf32", target(), profile.dir()));
         cmd.current_dir(workspace());
+        if verbose {
+            println!("Executing {:?}", cmd);
+        }
         let status = cmd.status()?;
         if !status.success() {
             return Err("objcopy failed".into());
@@ -204,13 +228,16 @@ fn dist(profile: Build) -> Result<()> {
     Ok(())
 }
 
-fn test(profile: Build) -> Result<()> {
+fn test(profile: Build, verbose: bool) -> Result<()> {
     let mut cmd = Command::new(cargo());
     cmd.current_dir(workspace());
     cmd.arg("test");
     cmd.arg("--workspace");
     exclude_other_arches(&mut cmd);
     profile.add_build_arg(&mut cmd);
+    if verbose {
+        println!("Executing {:?}", cmd);
+    }
     let status = cmd.status()?;
     if !status.success() {
         return Err("test failed".into());
@@ -218,11 +245,14 @@ fn test(profile: Build) -> Result<()> {
     Ok(())
 }
 
-fn clippy(profile: Build) -> Result<()> {
+fn clippy(profile: Build, verbose: bool) -> Result<()> {
     let mut cmd = Command::new(cargo());
     cmd.current_dir(workspace());
     cmd.arg("clippy");
     profile.add_build_arg(&mut cmd);
+    if verbose {
+        println!("Executing {:?}", cmd);
+    }
     let status = cmd.status()?;
     if !status.success() {
         return Err("build kernel failed".into());
@@ -230,46 +260,52 @@ fn clippy(profile: Build) -> Result<()> {
     Ok(())
 }
 
-fn run(profile: Build) -> Result<()> {
-    dist(profile)?;
+fn run(profile: Build, verbose: bool) -> Result<()> {
+    dist(profile, verbose)?;
 
     match arch().as_str() {
         "x86_64" => {
-            let status = Command::new(qemu_system())
-                .arg("-nographic")
-                //.arg("-curses")
-                .arg("-M")
-                .arg("q35")
-                .arg("-cpu")
-                .arg("qemu64,pdpe1gb,xsaveopt,fsgsbase,apic,msr")
-                .arg("-smp")
-                .arg("8")
-                .arg("-m")
-                .arg("8192")
-                //.arg("-device")
-                //.arg("ahci,id=ahci0")
-                //.arg("-drive")
-                //.arg("id=sdahci0,file=sdahci0.img,if=none")
-                //.arg("-device")
-                //.arg("ide-hd,drive=sdahci0,bus=ahci0.0")
-                .arg("-kernel")
-                .arg(format!("target/{}/{}/r9.elf32", target(), profile.dir()))
-                .current_dir(workspace())
-                .status()?;
+            let mut cmd = Command::new(qemu_system());
+            cmd.arg("-nographic");
+            //cmd.arg("-curses");
+            cmd.arg("-M");
+            cmd.arg("q35");
+            cmd.arg("-cpu");
+            cmd.arg("qemu64,pdpe1gb,xsaveopt,fsgsbase,apic,msr");
+            cmd.arg("-smp");
+            cmd.arg("8");
+            cmd.arg("-m");
+            cmd.arg("8192");
+            //cmd.arg("-device");
+            //cmd.arg("ahci,id=ahci0");
+            //cmd.arg("-drive");
+            //cmd.arg("id=sdahci0,file=sdahci0.img,if=none");
+            //cmd.arg("-device");
+            //cmd.arg("ide-hd,drive=sdahci0,bus=ahci0.0");
+            cmd.arg("-kernel");
+            cmd.arg(format!("target/{}/{}/r9.elf32", target(), profile.dir()));
+            cmd.current_dir(workspace());
+            if verbose {
+                println!("Executing {:?}", cmd);
+            }
+            let status = cmd.status()?;
             if !status.success() {
                 return Err("qemu failed".into());
             }
         }
         "aarch64" => {
-            let status = Command::new(qemu_system())
-                .arg("-nographic")
-                //.arg("-curses")
-                .arg("-M")
-                .arg("raspi3b")
-                .arg("-kernel")
-                .arg(format!("target/{}/{}/aarch64", target(), profile.dir()))
-                .current_dir(workspace())
-                .status()?;
+            let mut cmd = Command::new(qemu_system());
+            cmd.arg("-nographic");
+            //cmd.arg("-curses");
+            cmd.arg("-M");
+            cmd.arg("raspi3b");
+            cmd.arg("-kernel");
+            cmd.arg(format!("target/{}/{}/aarch64", target(), profile.dir()));
+            cmd.current_dir(workspace());
+            if verbose {
+                println!("Executing {:?}", cmd);
+            }
+            let status = cmd.status()?;
             if !status.success() {
                 return Err("qemu failed".into());
             }
@@ -282,22 +318,25 @@ fn run(profile: Build) -> Result<()> {
     Ok(())
 }
 
-fn accelrun(profile: Build) -> Result<()> {
-    dist(profile)?;
-    let status = Command::new(qemu_system())
-        .arg("-nographic")
-        .arg("-accel")
-        .arg("kvm")
-        .arg("-cpu")
-        .arg("host,pdpe1gb,xsaveopt,fsgsbase,apic,msr")
-        .arg("-smp")
-        .arg("8")
-        .arg("-m")
-        .arg("8192")
-        .arg("-kernel")
-        .arg(format!("target/{}/{}/r9.elf32", target(), profile.dir()))
-        .current_dir(workspace())
-        .status()?;
+fn accelrun(profile: Build, verbose: bool) -> Result<()> {
+    dist(profile, verbose)?;
+    let mut cmd = Command::new(qemu_system());
+    cmd.arg("-nographic");
+    cmd.arg("-accel");
+    cmd.arg("kvm");
+    cmd.arg("-cpu");
+    cmd.arg("host,pdpe1gb,xsaveopt,fsgsbase,apic,msr");
+    cmd.arg("-smp");
+    cmd.arg("8");
+    cmd.arg("-m");
+    cmd.arg("8192");
+    cmd.arg("-kernel");
+    cmd.arg(format!("target/{}/{}/r9.elf32", target(), profile.dir()));
+    cmd.current_dir(workspace());
+    if verbose {
+        println!("Executing {:?}", cmd);
+    }
+    let status = cmd.status()?;
     if !status.success() {
         return Err("qemu failed".into());
     }
@@ -320,11 +359,9 @@ fn workspace() -> PathBuf {
 fn exclude_other_arches(cmd: &mut Command) {
     match arch().as_str() {
         "x86_64" => {
-            println!("excluding aarch64");
             cmd.arg("--exclude").arg("aarch64");
         }
         "aarch64" => {
-            println!("excluding x86_64");
             cmd.arg("--exclude").arg("x86_64");
         }
         _ => {}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -144,20 +144,8 @@ fn build(profile: Build) -> Result<()> {
     cmd.arg("--target").arg(format!("lib/{}.json", target()));
     cmd.arg("--workspace");
     cmd.arg("--exclude").arg("xtask");
-
-    // Exclude architectures other than the one being built
-    match arch().as_str() {
-        "x86_64" => {
-            cmd.arg("--exclude").arg("aarch64");
-        }
-        "aarch64" => {
-            cmd.arg("--exclude").arg("x86_64");
-        }
-        _ => {}
-    }
-
+    exclude_other_arches(&mut cmd);
     profile.add_build_arg(&mut cmd);
-    println!("{:?}", cmd);
     let status = cmd.status()?;
     if !status.success() {
         return Err("build kernel failed".into());
@@ -324,4 +312,19 @@ fn clean() -> Result<()> {
 
 fn workspace() -> PathBuf {
     Path::new(&env!("CARGO_MANIFEST_DIR")).ancestors().nth(1).unwrap().to_path_buf()
+}
+
+// Exclude architectures other than the one being built
+fn exclude_other_arches(cmd: &mut Command) {
+    match arch().as_str() {
+        "x86_64" => {
+            println!("excluding aarch64");
+            cmd.arg("--exclude").arg("aarch64");
+        }
+        "aarch64" => {
+            println!("excluding x86_64");
+            cmd.arg("--exclude").arg("x86_64");
+        }
+        _ => {}
+    }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -208,6 +208,8 @@ fn test(profile: Build) -> Result<()> {
     let mut cmd = Command::new(cargo());
     cmd.current_dir(workspace());
     cmd.arg("test");
+    cmd.arg("--workspace");
+    exclude_other_arches(&mut cmd);
     profile.add_build_arg(&mut cmd);
     let status = cmd.status()?;
     if !status.success() {


### PR DESCRIPTION
Build and run aarch64 as follows:
  `ARCH=aarch64 TARGET=aarch64-unknown-none-elf cargo xtask qemu`

- Added support for xtask to build and run aarch64 kernel (raspi3)
- Initial raspi3-focussed aarch64 kernel
- Added raspi3 uart support (pl011)
- Added vscode debugger qemu attach config
- Adde `--verbose` flag to xtasks to print commands used during build

Todo
- Raspi4 support
- Should runtime.rs be in port?
- github action CI support