### PR TITLE
Fix xtask test (and CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We use `cargo` and the `xtask` pattern to build the kernel.
 
 To build r9 for x86_64, we assume you have cloned the git repository
 somewhere convenient.  Then simply change into the top-level
-directory and, `cargo xtask build --arch x86_64`.
+directory and, `cargo xtask build --arch x86-64`.
 
 To build for aarch64, run `cargo xtask build --arch aarch64` (Currently only Raspberry Pi 3 is supported).
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -37,7 +37,7 @@ impl BuildParams {
         let profile =
             if matches.contains_id("release") { Profile::Release } else { Profile::Debug };
         let verbose = matches.contains_id("verbose");
-        let arch = matches.get_one("arch").unwrap_or(&Arch::X86_64);
+        let arch = matches.try_get_one("arch").ok().flatten().unwrap_or(&Arch::X86_64);
         let wait_for_gdb = matches.try_contains_id("gdb").unwrap_or(false);
 
         Self { arch: *arch, profile: profile, verbose: verbose, wait_for_gdb: wait_for_gdb }


### PR DESCRIPTION
We gather all subcommand options into a single BuildParams.  If we call get_one for a match that doesn't belong to a particular subcommand, it panics.  This change uses the non-panicking try_get_one instead.

It may be better to split up BuildParams some day, but I don't see a clean way to do so yet.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>