### PR TITLE
Enable UART before MMU enabled on aarch64

### DIFF
--- a/aarch64/src/devcons.rs
+++ b/aarch64/src/devcons.rs
@@ -1,6 +1,5 @@
 // Racy to start.
 
-use core::arch::aarch64;
 use core::mem;
 use core::mem::MaybeUninit;
 use core::ptr;
@@ -380,9 +379,7 @@ impl Uart for MiniUart {
     fn putb(&self, b: u8) {
         // Wait for UART to become ready to transmit
         while read_reg(self.miniuart_reg, AUX_MU_LSR) & (1 << 5) == 0 {
-            unsafe {
-                aarch64::__nop();
-            }
+            core::hint::spin_loop();
         }
         write_reg(self.miniuart_reg, AUX_MU_IO, b as u32);
     }

--- a/aarch64/src/main.rs
+++ b/aarch64/src/main.rs
@@ -1,5 +1,6 @@
 #![feature(alloc_error_handler)]
 #![feature(asm_const)]
+#![feature(stdsimd)]
 #![cfg_attr(not(any(test, feature = "cargo-clippy")), no_std)]
 #![cfg_attr(not(test), no_main)]
 #![allow(clippy::upper_case_acronyms)]
@@ -17,12 +18,16 @@ use port::println;
 #[no_mangle]
 pub extern "C" fn main9(dtb_ptr: u64) {
     let dt = unsafe { DeviceTree::from_u64(dtb_ptr).unwrap() };
-
     devcons::init(&dt);
+
     println!();
     println!("r9 from the Internet");
     println!("DTB found at: {:#x}", dtb_ptr);
+
+    // Assume we've got MMU set up, so drop early console for the locking console
+    port::devcons::drop_early_console();
     println!("looping now");
+
     #[allow(clippy::empty_loop)]
     loop {}
 }

--- a/port/src/devcons.rs
+++ b/port/src/devcons.rs
@@ -20,11 +20,13 @@ pub trait Uart {
     fn putb(&self, b: u8);
 }
 
-pub struct Console;
-
+static mut EARLY_CONS: Option<&'static mut dyn Uart> = None;
 static CONS: Lock<Option<&'static mut dyn Uart>> = Lock::new("cons", None);
 
+pub struct Console;
+
 impl Console {
+    /// Create a locking console.  Assumes at this point we can use atomics.
     pub fn new<F>(uart_fn: F) -> Self
     where
         F: FnOnce() -> &'static mut dyn Uart,
@@ -32,6 +34,17 @@ impl Console {
         static mut NODE: LockNode = LockNode::new();
         let mut cons = CONS.lock(unsafe { &NODE });
         *cons = Some(uart_fn());
+        Self
+    }
+
+    /// Create an early, non-locking console.  Assumes at this point we cannot use atomics.
+    /// Once atomics can be used safely, drop_early_console should be called so we switch
+    /// to the locking console.
+    pub fn new_early<F>(uart_fn: F) -> Self
+    where
+        F: FnOnce() -> &'static mut dyn Uart,
+    {
+        unsafe { EARLY_CONS.replace(uart_fn()) };
         Self
     }
 
@@ -47,10 +60,17 @@ impl Console {
 
     pub fn putstr(&mut self, s: &str) {
         // XXX: Just for testing.
-        static mut NODE: LockNode = LockNode::new();
-        let mut uart = CONS.lock(unsafe { &NODE });
-        for b in s.bytes() {
-            self.putb(uart.as_deref_mut().unwrap(), b);
+
+        if let Some(uart) = unsafe { &mut EARLY_CONS } {
+            for b in s.bytes() {
+                self.putb(*uart, b);
+            }
+        } else {
+            static mut NODE: LockNode = LockNode::new();
+            let mut uart = CONS.lock(unsafe { &NODE });
+            for b in s.bytes() {
+                self.putb(uart.as_deref_mut().unwrap(), b);
+            }
         }
     }
 }
@@ -60,6 +80,13 @@ impl fmt::Write for Console {
         self.putstr(s);
         Ok(())
     }
+}
+
+pub fn drop_early_console() {
+    static mut NODE: LockNode = LockNode::new();
+    let mut cons = CONS.lock(unsafe { &NODE });
+    let earlycons = unsafe { EARLY_CONS.take() };
+    *cons = earlycons;
 }
 
 pub fn print(args: fmt::Arguments) {


### PR DESCRIPTION
- Add early, non-locking console for use where atomics not available.  This should be changed to the default locking console as soon as practical.  Only used in aarch64 for now.
- Use of early console is hidden from callers of println
- Add MiniUART for raspberry pi
- Add support for compressed aarch64 kernel

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>