### PR TITLE
use of DeviceTree library and integration with riscv64 devcons

### DIFF
--- a/riscv64/src/devcons.rs
+++ b/riscv64/src/devcons.rs
@@ -1,14 +1,27 @@
 // Racy to start.
 
-use crate::uart16550::Uart16550;
-use port::devcons::Console;
+use core::mem::MaybeUninit;
 
-pub fn init() {
+use crate::uart16550::Uart16550;
+use port::{devcons::Console, fdt::DeviceTree};
+
+pub fn init(dt: &DeviceTree) {
+    let ns16550a_reg = dt
+        .find_compatible("ns16550a")
+        .next()
+        .and_then(|uart| dt.property_translated_reg_iter(uart).next())
+        .and_then(|reg| reg.regblock())
+        .unwrap();
+
     Console::new(|| {
-        static mut UART: Uart16550 = Uart16550::new(0x1000_0000);
+        let mut uart = Uart16550::new(ns16550a_reg);
+        uart.init(115_200);
+
+        static mut UART: MaybeUninit<Uart16550> = MaybeUninit::uninit();
+
         unsafe {
-            UART.init(115_200);
-            &mut UART
+            UART.write(uart);
+            UART.assume_init_mut()
         }
     });
 }

--- a/riscv64/src/main.rs
+++ b/riscv64/src/main.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::upper_case_acronyms)]
 #![forbid(unsafe_op_in_unsafe_fn)]
 
+use port::fdt::DeviceTree;
 use port::println;
 
 mod devcons;
@@ -17,11 +18,15 @@ mod uart16550;
 core::arch::global_asm!(include_str!("l.S"));
 
 #[no_mangle]
-pub extern "C" fn main9(hartid: usize, opaque: usize) -> ! {
-    devcons::init();
+pub extern "C" fn main9(hartid: usize, dtb_ptr: u64) -> ! {
+    let dt = unsafe { DeviceTree::from_u64(dtb_ptr).unwrap() };
+
+    devcons::init(&dt);
     println!();
     println!("r9 from the Internet");
-    println!("Domain0 Boot HART = {}, Domain0 Next Arg1 = {:#x}", hartid, opaque);
+    println!("Domain0 Boot HART = {hartid}");
+    println!("DTB found at: {dtb_ptr:#x}");
+
     #[cfg(not(test))]
     sbi::shutdown();
     #[cfg(test)]


### PR DESCRIPTION
instead of the hardcoded register location use the new fdt code
updates xtask target "dist to support riscv64

Signed-off-by: Stefan Hertenberger <erde74@gmail.com>