### PR TITLE
x86_64: clean up assembler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,12 +11,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bare-metal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
-
-[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,16 +86,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-hal"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
-dependencies = [
- "nb 0.1.3",
- "void",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,9 +114,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856b5cb0902c2b6d65d5fd97dfa30f9b70c7538e770b98eab5ed52d8db923e01"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "io-lifetimes"
@@ -167,21 +151,6 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.0.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "once_cell"
@@ -254,23 +223,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "riscv"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2856a701069e2d262b264750d382407d272d5527f7a51d3777d1805b4e2d3c"
-dependencies = [
- "bare-metal",
- "bit_field",
- "embedded-hal",
-]
-
-[[package]]
 name = "riscv64"
 version = "0.1.0"
 dependencies = [
  "port",
- "riscv",
- "uart_16550",
 ]
 
 [[package]]
@@ -286,12 +242,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "strsim"
@@ -320,17 +270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uart_16550"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b074eb9300ad949edd74c529c0e8d451625af71bb948e6b65fe69f72dc1363d9"
-dependencies = [
- "bitflags",
- "rustversion",
- "x86_64 0.14.10",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,18 +280,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "volatile"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
 
 [[package]]
 name = "winapi"
@@ -469,18 +396,6 @@ dependencies = [
  "bitstruct",
  "port",
  "x86",
-]
-
-[[package]]
-name = "x86_64"
-version = "0.14.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
-dependencies = [
- "bit_field",
- "bitflags",
- "rustversion",
- "volatile",
 ]
 
 [[package]]

--- a/x86_64/src/l.S
+++ b/x86_64/src/l.S
@@ -36,75 +36,34 @@
 
 .set PTSZ,			4096
 .set PGSZ,			4096
-.set MACHSTKSZ,			(8 * PGSZ)
+.set MACHSTKSZ,			(8*PGSZ)
 
 .set KZERO,			0xffff800000000000
-.set MiB,			(1 << 20)
+.set MiB,			(1<<20)
 .set KSYS,			(KZERO+MiB+PGSZ)
 .set KTZERO,			(KZERO+2*MiB)
 
-/* Cr0 */
-.set Pe, 0x00000001 /* Protected Mode Enable */
-.set Mp, 0x00000002 /* Monitor Coprocessor */
-.set Em, 0x00000004 /* Emulate Coprocessor */
-.set Ts, 0x00000008 /* Task Switched */
-.set Et, 0x00000010 /* Extension Type */
-.set Ne, 0x00000020 /* Numeric Error  */
-.set Wp, 0x00010000 /* Write Protect */
-.set Am, 0x00040000 /* Alignment Mask */
-.set Nw, 0x20000000 /* Not Writethrough */
-.set Cd, 0x40000000 /* Cache Disable */
-.set Pg, 0x80000000 /* Paging Enable */
+.set Cr0PE,			(1<<0)		// Protected Mode Enable
+.set Cr0MP,			(1<<1)		// Monitor Coprocessor
+.set Cr0TS,			(1<<7)		// Task Switched
+.set Cr0WP,			(1<<16)		// Write Protect
+.set Cr0NW,			(1<<29)		// Not Writethrough
+.set Cr0CD,			(1<<30)		// Cache Disable
+.set Cr0PG,			(1<<31)		// Paging Enable
 
-/* Cr3 */
-.set Pwt, 0x00000008 /* Page-Level Writethrough */
-.set Pcd, 0x00000010 /* Page-Level Cache Disable */
+.set Cr4PSE,			(1<<4)		// Page-Size Extensions
+.set Cr4PAE,			(1<<5)		// Physical Address Extension
+.set Cr4PGE,			(1<<7)		// Page-Global Enable
 
-/* Cr4 */
-.set Vme, 0x00000001        /* Virtual-8086 Mode Extensions */
-.set Pvi, 0x00000002        /* Protected Mode Virtual Interrupts */
-.set Tsd, 0x00000004        /* Time-Stamp Disable */
-.set De, 0x00000008         /* Debugging Extensions */
-.set Pse, 0x00000010        /* Page-Size Extensions */
-.set Pae, 0x00000020        /* Physical Address Extension */
-.set Mce, 0x00000040        /* Machine Check Enable */
-.set Pge, 0x00000080        /* Page-Global Enable */
-.set Pce, 0x00000100        /* Performance Monitoring Counter Enable */
-.set Osfxsr, 0x00000200     /* FXSAVE/FXRSTOR Support */
-.set Osxmmexcpt, 0x00000400 /* Unmasked Exception Support */
+.set IA32_EFER,			0xc0000080	// Extended Feature Enable
 
-/* MSRs */
-.set Efer, 0xc0000080         /* Extended Feature Enable */
-.set Star, 0xc0000081         /* Legacy Target IP and [CS]S */
-.set Lstar, 0xc0000082        /* Long Mode Target IP */
-.set Cstar, 0xc0000083        /* Compatibility Target IP */
-.set Sfmask, 0xc0000084       /* SYSCALL Flags Mask */
-.set FSbase, 0xc0000100       /* 64-bit FS Base Address */
-.set GSbase, 0xc0000101       /* 64-bit GS Base Address */
-.set KernelGSbase, 0xc0000102 /* SWAPGS instruction */
+.set EferSCE,			(1<<0)		// System Call Extension
+.set EferLME,			(1<<8)		// Long Mode Enable
+.set EferNXE,			(1<<11)		// No-Execute Enable
 
-/* Efer */
-.set Sce, 0x00000001   /* System Call Extension */
-.set Lme, 0x00000100   /* Long Mode Enable */
-.set Lma, 0x00000400   /* Long Mode Active */
-.set Nxe, 0x00000800   /* No-Execute Enable */
-.set Svme, 0x00001000  /* SVM Extension Enable */
-.set Ffxsr, 0x00004000 /* Fast FXSAVE/FXRSTOR */
-
-/* PML4E/PDPE/PDE/PTE */
-.set PteP, 0x0000000000000001     /* Present */
-.set PteRW, 0x0000000000000002    /* Read/Write */
-.set PteU, 0x0000000000000004     /* User/Supervisor */
-.set PtePWT, 0x0000000000000008   /* Page-Level Write Through */
-.set PtePCD, 0x0000000000000010   /* Page Level Cache Disable */
-.set PteA, 0x0000000000000020     /* Accessed */
-.set PteD, 0x0000000000000040     /* Dirty */
-.set PtePS, 0x0000000000000080    /* Page Size */
-.set Pte4KPAT, PtePS              /* PTE PAT */
-.set PteG, 0x0000000000000100     /* Global */
-.set Pte2MPAT, 0x0000000000001000 /* PDE PAT */
-.set Pte1GPAT, Pte2MPAT           /* PDPE PAT */
-.set PteNX, 0x8000000000000000ULL /* No Execute */
+.set PteP,			(1<<0)		// Present
+.set PteRW,			(1<<1)		// Read/Write
+.set PtePS,			(1<<7)		// Page Size
 
 .align 4
 .section .boottext, "awx"
@@ -195,7 +154,8 @@ start:
 	// %eax now points to the page after the EPML2s, which is the real
 	// self-referential PML4.
 	// Map the first 192 entries for the upper portion of the address
-	// to PML3s; this is the primordial root of sharing for the kernel.
+	// space to PML3s; this is the primordial root of sharing for the
+	// kernel.
 	movl	%eax, %edx
 	addl	$(PTSZ|PteRW|PteP), %edx	// PML3[0] at PML4 + PTSZ
 	movl	$256, %ecx
@@ -213,19 +173,19 @@ start:
 	// make an inter-segment jump to the Long Mode code.
 	// It`s all in 32-bit mode until the jump is made.
 	movl	%cr4, %eax
-	andl	$~Pse, %eax			// Page Size
-	orl	$(Pge|Pae), %eax		// Page Global, Phys. Address
+	andl	$~Cr4PSE, %eax			// Page Size
+	orl	$(Cr4PGE|Cr4PAE), %eax		// Page Global, Phys. Address
 	movl	%eax, %cr4
 
-	movl	$Efer, %ecx			// Extended Feature Enable
+	movl	$IA32_EFER, %ecx		// Extended Feature Enable
 	rdmsr
-	orl	$Lme, %eax			// Long Mode Enable
-	orl	$Nxe, %eax			// Long Mode Enable
+	// Enable long mode, NX bit in PTEs and SYSCALL/SYSREG.
+	orl	$(EferSCE|EferLME|EferNXE), %eax
 	wrmsr
 
 	movl	%cr0, %edx
-	andl	$~(Cd|Nw|Ts|Mp), %edx
-	orl	$(Pg|Wp), %edx			// Paging Enable
+	andl	$~(Cr0CD|Cr0NW|Cr0TS|Cr0MP), %edx
+	orl	$(Cr0PG|Cr0WP), %edx		// Paging Enable
 	movl	%edx, %cr0
 
 	// Load the 64-bit GDT
@@ -339,7 +299,7 @@ b1978:
 	lgdtl	(APENTRY+(apgdtdesc-b1978))
 
 	movl	%cr0, %eax
-	orl	$Pe, %eax
+	orl	$Cr0PE, %eax
 	movl	%eax, %cr0
 
 	ljmpl   $GdtCODE32, $(b1982-KZERO)
@@ -384,19 +344,18 @@ b1982:
 
 	// Enable and activate Long Mode.
 	movl	%cr4, %eax
-	andl	$~Pse, %eax			// Page Size
-	orl	$(Pge|Pae), %eax		// Page Global, Phys. Address
+	andl	$~Cr4PSE, %eax			// Page Size
+	orl	$(Cr4PGE|Cr4PAE), %eax		// Page Global, Phys. Address
 	movl	%eax, %cr4
 
-	movl	$Efer, %ecx			// Extended Feature Enable
+	movl	$IA32_EFER, %ecx		// Extended Feature Enable
 	rdmsr
-	orl	$Lme, %eax			// Long Mode Enable
-	orl	$Nxe, %eax			// Long Mode Enable
-	wrmsr
+	orl	$(EferSCE|EferLME|EferNXE), %eax
+	wrmsr					// Long Mode Enable
 
 	movl	%cr0, %edx
-	andl	$~(Cd|Nw|Ts|Mp), %edx
-	orl	$(Pg|Wp), %edx			// Paging Enable
+	andl	$~(Cr0CD|Cr0NW|Cr0TS|Cr0MP), %edx
+	orl	$(Cr0PG|Cr0WP), %edx		// Paging Enable
 	movl	%edx, %cr0
 
 	ljmp	$GdtCODE64, $(1f-KZERO)


### PR DESCRIPTION
A lot of bit definitions and so on were simply
copy/pasted from Harvey; clean these up to make
them a little more r9-like.

Also, `cargo update`.

Signed-off-by: Dan Cross <cross@gajendra.net>