### PR TITLE
Enable aarch64 mmu immediately

### DIFF
--- a/aarch64/src/kernel.ld
+++ b/aarch64/src/kernel.ld
@@ -5,35 +5,33 @@
 ENTRY(start)
 
 SECTIONS {
-	/*
-	 * Raspberry Pi start address is 0x80_0000.
-	 */
-	/* . = 0xffff800000100000; */
+	/* Entrypoint for Raspberry Pi will be at 0x80000 */
+	. = 0xffff800000100000 - 0x80000;
 
-	. = 0x80000;
-
-	PROVIDE(boottext = .);
+	boottext = .;
 	.text.boot : ALIGN(4096) {
 		*(.boottext .bootdata)
 		. = ALIGN(4096);
-		PROVIDE(eboottext = .);
+		eboottext = .;
 		. = ALIGN(2097152);
-		PROVIDE(esys = .);
+		esys = .;
 	}
 
-	PROVIDE(text = .);
+	text = .;
 	.text : ALIGN(4096) {
 		*(.text* .stub .gnu.linkonce.t.*)
 		. = ALIGN(2097152);	
-		PROVIDE(etext = .);
+		etext = .;
 	}
 
+	rodata = .;
 	.rodata : ALIGN(4096) {
 		*(.rodata* .gnu.linkonce.r.*)
 		. = ALIGN(2097152);
-		PROVIDE(erodata = .);
+		erodata = .;
 	}
 
+	data = .;
 	.data : ALIGN(4096) {
 		*(.data*)
 	}
@@ -43,15 +41,15 @@ SECTIONS {
 	.got.plt : ALIGN(4096) {
 		*(.got.plt)
 	}
-	PROVIDE(edata = .);
+	edata = .;
 
-	PROVIDE(bss = .);
+	bss = .;
 	.bss : ALIGN(4096) {
 		*(.bss*)
 		*(COMMON)
 		. = ALIGN(2097152);
 	}
-	PROVIDE(end = .);
+	end = .;
 
 	/DISCARD/ : {
 		*(.eh_frame .note.GNU-stack)

--- a/aarch64/src/l.S
+++ b/aarch64/src/l.S
@@ -10,26 +10,71 @@ STACKSZ = 4096*4
 .equ	SCR_EL3_RW,		(1<<10)
 
 .equ	SPSR_EL3_M_EL2H,	(1<<3) | (1<<0)	// Exception level and SP: EL2H
-.equ	SPSR_EL3_F,		(1<<6)	// FIQ
-.equ	SPSR_EL3_I,		(1<<7)	// IRQ
-.equ	SPSR_EL3_A,		(1<<8)	// SError
-.equ	SPSR_EL3_D,		(1<<9)	// Debug exception
+.equ	SPSR_EL3_F,		(1<<6)		// FIQ
+.equ	SPSR_EL3_I,		(1<<7)		// IRQ
+.equ	SPSR_EL3_A,		(1<<8)		// SError
+.equ	SPSR_EL3_D,		(1<<9)		// Debug exception
 
 .equ	HCR_EL2_RW,		(1<<31)
 
 .equ	SPSR_EL2_M_EL1H,	(1<<2) | (1<<0)	// Exception level and SP: EL1h
-.equ	SPSR_EL2_F,		(1<<6)	// FIQ
-.equ	SPSR_EL2_I,		(1<<7)	// IRQ
-.equ	SPSR_EL2_A,		(1<<8)	// SError
-.equ	SPSR_EL2_D,		(1<<9)	// Debug exception
+.equ	SPSR_EL2_F,		(1<<6)		// FIQ
+.equ	SPSR_EL2_I,		(1<<7)		// IRQ
+.equ	SPSR_EL2_A,		(1<<8)		// SError
+.equ	SPSR_EL2_D,		(1<<9)		// Debug exception
 
 .equ	CPACR_EL1_FPEN,		(1<<21) | (1<<20)	// Don't trap FPU instr at EL1,0
+
+.equ	TCR_EL1_T0SZ,		(16<<0)		// 2^(64-N) size offset of region addressed by TTBR0_EL1: 2^(64-N)
+.equ	TCR_EL1_TG0,		(0<<14)		// TTBR0_EL1 4KiB granule
+.equ	TCR_EL1_T1SZ,		(16<<16)	// 2^(64-N) size offset of region addressed by TTBR1_EL1: 2^(64-N)
+.equ	TCR_EL1_TG1,		(2<<30)		// TTBR1_EL1 4KiB granule
+.equ	TCR_EL1_IPS,		(1<<1)		// 40bit physical addresses (qemu default)
+
+.equ	SCTLR_EL1_M,		(1<<0)		// Enable MMU
+
+// Preset memory attributes.  This register stores 8 8-bit presets that are
+// referenced by index in the page table entries:
+//  [0] 0x00 - Device (Non-gathering, non-reordering, no early write acknowledgement (most restrictive))
+//  [1] 0xff - Normal
+.equ	MAIR_EL1,		0xff00
+.equ	PT_MAIR_DEVICE,		(0<<2)		// Use device memory attributes
+.equ	PT_MAIR_NORMAL,		(1<<2)		// Use normal memory attributes
+
+.equ	PT_PAGE,		3		// 4KiB granule
+.equ	PT_BLOCK,		1		// 2MiB granule
+
+// Page table entry AP Flag
+.equ	PT_AP_KERNEL_RW,	(0<<6)		// Kernel: rw
+.equ	PT_AP_KERNEL_RW_USER_RW,(1<<6)		// Kernel: rw, User: rw
+.equ	PT_AP_KERNEL_RO,	(2<<6)		// Kernel: r
+.equ	PT_AP_KERNEL_RO_USER_RO,(3<<6)		// Kernel: r, User: r
+
+.equ	PT_AF,			(1<<10)		// Access Flag
+
+.equ	PT_PXN,			(1<<53)		// Priviledged execute never
+.equ	PT_UXN,			(1<<54)		// User execute never
+
+// Cache shareability
+.equ	PT_NOSH,		(0<<8)		// Non-shareable (single core)
+.equ	PT_OSH,			(2<<8)		// Outer shareable (shared across CPUs, GPU)
+.equ	PT_ISH,			(3<<8)		// Inner shareable (shared across CPUs)
+
+// This defines the kernel's virtual address location.
+// This value splits a 48 bit address space exactly in half, with the half
+// beginning with 1 going to the kernel.
+.equ	KZERO,			0xffff800000000000
+.equ	MiB,			(1<<20)
+.equ	GiB,			(1<<30)
+.equ	KTZERO,			(KZERO+2*MiB)	// Virtual base of kernel text
 
 .section .boottext, "awx"
 .globl start
 start:
 	// Cache dtb pointer so we can pass to main9 later
-	mov	x30, x0
+	mov	x27, x0
+	// Cache entrypoint (offset)
+	mov	x28, x4
 
 	// All cores other than 0 should just hang
 	mrs	x0, mpidr_el1
@@ -79,7 +124,112 @@ el2:	// Now in EL2, so prepare jump to EL1
 	msr	elr_el2, x0
 	eret
 
-el1:	// In EL1, so set up the initial stack
+el1:	// In EL1
+
+	// AArch64 memory management examples
+	//  https://developer.arm.com/documentation/102416/0100
+
+	// AArch64 Address Translation
+	//  https://developer.arm.com/documentation/100940/0101
+
+	// The kernel has been loaded at the entrypoint, but the
+	// addresses used in the elf are virtual addresses in the higher half.
+	// If we try to access them, the CPU will trap, so the next step is to
+	// enable the MMU and identity map the kernel virtual addresses to the
+	// physical addresses that the kernel was loaded into.
+
+	// The Aarch64 is super flexible.  We can have page tables (granules)
+	// of 4, 16, or 64KiB.  If we assume 4KiB granules, we would have:
+	//  [47-39] Index into L4 table, used to get address of the L3 table
+	//  [38-30] Index into L3 table, used to get address of the L2 table
+	//  [29-21] Index into L2 table, used to get address of the L1 table
+	//  [20-12] Index into L1 table, used to get address of physical page 
+	//  [11-0]  Offset into physical page corresponding to virtual address
+	// L4-L1 simply refers to the page table with L1 always being the last
+	// to be translated, giving the address of the physical page.
+	// With a 4KiB granule, each index is 9 bits, so there are 512 (2^9)
+	// entries in each table.  In this example the physical page would
+	// also be 4KiB.
+	
+	// If we reduce the number of page tables from 4 to 3 (L3 to L1),
+	// we have 21 bits [20-0] for the physical page offset, giving 2MiB
+	// pages.  If we reduce to 2 tables, we have 30 bits [29-0], giving
+	// 1GiB pages.
+
+	// If we use 16KiB granules, the virtual address is split as follows:
+	//  [46-36] Index into L3 table, used to get address of the L2 table
+	//  [35-25] Index into L2 table, used to get address of the L1 table
+	//  [24-14] Index into L1 table, used to get address of physical page 
+	//  [13-0]  Offset into physical page corresponding to virtual address
+	// The 14 bits in the offset results in 16KiB pages.  Each table is
+	// 16KiB, consisting of 2048 entries, so requiring 11 bits per index.
+	// If we instead use only 2 levels, that gives us bits [24-0] for the
+	// offset into the physical page, which gives us 32MiB page size.
+
+	// Finally, if we use 64KiB granules, the virtual address is split as
+	// follows:
+	//  [41-29] Index into L2 table, used to get address of the L1 table
+	//  [28-16] Index into L1 table, used to get address of physical page
+	//  [15-0]  Offset into physical page corresponding to virtual address
+	// The 16 bits in the offset results in 64KiB pages.  Each table is
+	// 64KiB, consisting of 8192 entries, so requiring 13 bits per index.
+	// If we instead use only 1 level, that gives us bits [28-0] for the
+	// offset into the physical page, which gives us 512MiB page size.
+
+	// The address of the top level table is stored in the translation table
+	// base registers.  ttbr0_el1 stores the address for the user space,
+	// ttbr1_el1 stores the address for the kernel, both for EL1.
+	// By default, ttbr1_el1 is used when the virtual address bit 55 is 1
+	// otherwise ttbr0_el1 is used.
+
+	// Memory attributes are set per page table entry, and are hierarchical,
+	// so settings at a higher page affect those they reference.
+
+	// Set up root tables for lower (ttbr0_el1) and higher (ttbr1_el1)
+	// addresses.  kernelpt4 is the root of the page hierarchy for addresses
+	// of the form 0xffff800000000000 (KZERO and above), while physicalpt4
+	// handles 0x0000000000000000 until KZERO.  Although what we really
+	// want is to move to virtual higher half addresses, we need to have
+	// ttbr0_el1 identity mapped during the transition until the PC is also
+	// in the higher half.  This is because the PC is still in the lower
+	// half immediately after the MMU is enabled.
+	adrp	x0, kernelpt4
+	msr	ttbr1_el1, x0
+	adrp	x0, physicalpt4
+	msr	ttbr0_el1, x0
+
+	// Set up the translation control register tcr_el1 as so:
+	//  TCR_EL1_T0SZ: Size offset of region addressed by TTBR0_EL1: 2^30)
+	//  TCR_EL1_T1SZ: Size offset of region addressed by TTBR1_EL1: 2^30)
+	//  TCR_EL1_TG0: 4KiB granule
+	//  TCR_EL1_TG1: 4KiB granule
+	//  TCR_EL1_IPS: 40 bit physical addresses
+	ldr	x0, =(TCR_EL1_T0SZ|TCR_EL1_T1SZ|TCR_EL1_TG0|TCR_EL1_TG1|TCR_EL1_IPS)
+	msr	tcr_el1, x0
+
+	// The mair_el1 register contains 8 different cache settings, to be
+	// referenced by index by any page table entry.
+	ldr	x0, =(MAIR_EL1)
+	msr	mair_el1, x0
+
+	// Force changes to be be seen before MMU enabled, then enable MMU
+	isb
+	mrs	x0, sctlr_el1
+	ldr	x1, =(SCTLR_EL1_M)
+	orr	x0, x0, x1
+	msr	sctlr_el1, x0
+
+	// Force changes to be be seen by next instruction.
+	// At this point the PC is still in the lower half, so we need to jump
+	// up to the higher half.
+	isb
+	mrs	x0, elr_el1
+	ldr	x20, =(higher_half)
+	br	x20
+
+higher_half:
+	// Now that the kernel is mapped, the MMU is enabled and we're in the
+	// higher half, we can set up the initial stack.
 	ldr	x0, =stack
 	add	x0, x0, #STACKSZ
 	mov	sp, x0
@@ -87,18 +237,40 @@ el1:	// In EL1, so set up the initial stack
 	// Clear bss
 	ldr	x0, =bss		// Start address
 	ldr	x1, =end		// End of bss
-1:
-	str	xzr, [x0], #8
+1:	str	xzr, [x0], #8
 	cmp	x0, x1
 	b.ne	1b
 
-	// Finally jump to rust
-	mov	x0, x30			// DTB pointer
+	// Jump to rust, passing DTB pointer (in x27, then map to upper half)
+	ldr	x0, =(KZERO)
+	add	x0, x0, x27
 	bl	main9
 
 .globl dnr
 dnr:	wfe
 	b	dnr
+
+// Early page tables for mapping the kernel to the higher half.
+// It's assumed that the kernelpt* page tables will only be used until the
+// full VM code is running.
+.balign 4096
+kernelpt4:
+	.space	(4096/2)
+	.quad	(kernelpt3 - KZERO) + (PT_PAGE)
+	.space	(4096/2) - (1*8)
+
+.balign 4096
+kernelpt3:
+ 	.quad	(0*2*GiB) + (PT_BLOCK|PT_AF|PT_AP_KERNEL_RW|PT_ISH|PT_UXN|PT_MAIR_NORMAL)
+	.space	(4096) - (1*8)
+
+// Early page table for identity mapping the kernel physical addresses.
+// Once we've jumped to the higher half, this will no longer be used.
+// (The pt3 table is the same for in both cases, so we can share.)
+.balign 4096
+physicalpt4:
+	.quad	(kernelpt3 - KZERO) + (PT_PAGE)
+	.space	(4096) - (1*8)
 
 .bss
 .balign	4096

--- a/aarch64/src/main.rs
+++ b/aarch64/src/main.rs
@@ -10,11 +10,58 @@ mod devcons;
 mod registers;
 mod trap;
 
+use core::ffi::c_void;
+use core::ptr;
 use port::fdt::DeviceTree;
 use port::println;
 
 #[cfg(not(test))]
 core::arch::global_asm!(include_str!("l.S"));
+
+fn print_binary_sections() {
+    extern "C" {
+        static boottext: *const c_void;
+        static eboottext: *const c_void;
+        static text: *const c_void;
+        static etext: *const c_void;
+        static rodata: *const c_void;
+        static erodata: *const c_void;
+        static data: *const c_void;
+        static edata: *const c_void;
+        static bss: *const c_void;
+        static end: *const c_void;
+    }
+
+    let bootcode_start: u64 = unsafe { ptr::addr_of!(boottext) as u64 };
+    let bootcode_end: u64 = unsafe { ptr::addr_of!(eboottext) as u64 };
+    let bootcode_size: u64 = bootcode_end - bootcode_start;
+
+    let text_start: u64 = unsafe { ptr::addr_of!(text) as u64 };
+    let text_end: u64 = unsafe { ptr::addr_of!(etext) as u64 };
+    let text_size: u64 = text_end - text_start;
+
+    let rodata_start: u64 = unsafe { ptr::addr_of!(rodata) as u64 };
+    let rodata_end: u64 = unsafe { ptr::addr_of!(erodata) as u64 };
+    let rodata_size: u64 = rodata_end - rodata_start;
+
+    let data_start: u64 = unsafe { ptr::addr_of!(data) as u64 };
+    let data_end: u64 = unsafe { ptr::addr_of!(edata) as u64 };
+    let data_size: u64 = data_end - data_start;
+
+    let bss_start: u64 = unsafe { ptr::addr_of!(bss) as u64 };
+    let bss_end: u64 = unsafe { ptr::addr_of!(end) as u64 };
+    let bss_size: u64 = bss_end - bss_start;
+
+    let total_size: u64 = bss_end - bootcode_start;
+
+    println!("Binary sections:");
+    println!("  boottext:\t{:#x}-{:#x} ({:#x})", bootcode_start, bootcode_end, bootcode_size);
+    println!("  text:\t\t{:#x}-{:#x} ({:#x})", text_start, text_end, text_size);
+    println!("  rodata:\t{:#x}-{:#x} ({:#x})", rodata_start, rodata_end, rodata_size);
+    println!("  data:\t\t{:#x}-{:#x} ({:#x})", data_start, data_end, data_size);
+    println!("  bss:\t\t{:#x}-{:#x} ({:#x})", bss_start, bss_end, bss_size);
+    println!("  total:\t{:#x}-{:#x} ({:#x})", bootcode_start, bss_end, total_size);
+}
 
 #[no_mangle]
 pub extern "C" fn main9(dtb_ptr: u64) {
@@ -26,6 +73,7 @@ pub extern "C" fn main9(dtb_ptr: u64) {
     println!();
     println!("r9 from the Internet");
     println!("DTB found at: {:#x}", dtb_ptr);
+    print_binary_sections();
 
     // Assume we've got MMU set up, so drop early console for the locking console
     port::devcons::drop_early_console();

--- a/aarch64/src/registers.rs
+++ b/aarch64/src/registers.rs
@@ -5,10 +5,10 @@ use num_enum::TryFromPrimitive;
 bitstruct! {
     #[derive(Copy, Clone)]
     pub struct EsrEl1(pub u64) {
-        iss: u32 = 0 .. 25;
+        iss: u32 = 0..25;
         il: bool = 25;
         ec: u8 = 26..32;
-        iss2: u8 = 32 .. 37;
+        iss2: u8 = 32..37;
     }
 }
 
@@ -63,4 +63,149 @@ pub enum ExceptionClass {
     WatchpointLowerEl = 52,
     WatchpointSameEl = 53,
     Brk = 60,
+}
+
+bitstruct! {
+    #[derive(Copy, Clone)]
+    pub struct EsrEl1IssInstructionAbort(pub u32) {
+        ifsc: u8 = 0..6;
+        s1ptw: bool = 7;
+        ea: bool = 9;
+        fnv: bool = 10;
+        set: u8 = 11..13;
+    }
+}
+
+impl EsrEl1IssInstructionAbort {
+    pub fn from_esr_el1(r: EsrEl1) -> Option<EsrEl1IssInstructionAbort> {
+        r.exception_class()
+            .ok()
+            .filter(|ec| *ec == ExceptionClass::InstructionAbortSameEl)
+            .map(|_| EsrEl1IssInstructionAbort(r.iss()))
+    }
+
+    pub fn instruction_fault(&self) -> Result<InstructionFaultStatusCode, u8> {
+        InstructionFaultStatusCode::try_from(self.ifsc()).map_err(|e| e.number)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, TryFromPrimitive)]
+#[repr(u8)]
+pub enum InstructionFaultStatusCode {
+    AddressSizeFaultLevel0 = 0,
+    AddressSizeFaultLevel1 = 1,
+    AddressSizeFaultLevel2 = 2,
+    AddressSizeFaultLevel3 = 3,
+    TranslationFaultLevel0 = 4,
+    TranslationFaultLevel1 = 5,
+    TranslationFaultLevel2 = 6,
+    TranslationFaultLevel3 = 7,
+    AccessFlagFaultLevel0 = 8,
+    AccessFlagFaultLevel1 = 9,
+    AccessFlagFaultLevel2 = 10,
+    AccessFlagFaultLevel3 = 11,
+    PermissionFaultLevel0 = 12,
+    PermissionFaultLevel1 = 13,
+    PermissionFaultLevel2 = 14,
+    PermissionFaultLevel3 = 15,
+    SyncExtAbortNotOnWalkOrUpdate = 16,
+    SyncExtAbortOnWalkOrUpdateLevelNeg1 = 19,
+    SyncExtAbortOnWalkOrUpdateLevel0 = 20,
+    SyncExtAbortOnWalkOrUpdateLevel1 = 21,
+    SyncExtAbortOnWalkOrUpdateLevel2 = 22,
+    SyncExtAbortOnWalkOrUpdateLevel3 = 23,
+    SyncParityOrEccErrOnMemAccessNotOnWalk = 24,
+    SyncParityOrEccErrOnMemAccessOnWalkOrUpdateLevelNeg1 = 27,
+    SyncParityOrEccErrOnMemAccessOnWalkOrUpdateLevel0 = 28,
+    SyncParityOrEccErrOnMemAccessOnWalkOrUpdateLevel1 = 29,
+    SyncParityOrEccErrOnMemAccessOnWalkOrUpdateLevel2 = 30,
+    SyncParityOrEccErrOnMemAccessOnWalkOrUpdateLevel3 = 31,
+    GranuleProtectFaultOnWalkOrUpdateLevelNeg1 = 35,
+    GranuleProtectFaultOnWalkOrUpdateLevel0 = 36,
+    GranuleProtectFaultOnWalkOrUpdateLevel1 = 37,
+    GranuleProtectFaultOnWalkOrUpdateLevel2 = 38,
+    GranuleProtectFaultOnWalkOrUpdateLevel3 = 39,
+    GranuleProtectFaultNotOnWalkOrUpdateLevel = 40,
+    AddressSizeFaultLevelNeg1 = 41,
+    TranslationFaultLevelNeg1 = 43,
+    TlbConflictAbort = 48,
+    UnsupportedAtomicHardwareUpdateFault = 49,
+}
+
+bitstruct! {
+    #[derive(Copy, Clone)]
+    pub struct Vaddr4K4K(pub u64) {
+        offset: u16 = 0..12;
+        l4idx: u16 = 12..21;
+        l3idx: u16 = 21..30;
+        l2idx: u16 = 30..39;
+        l1idx: u16 = 39..48;
+    }
+}
+
+bitstruct! {
+    #[derive(Copy, Clone)]
+    pub struct Vaddr4K1G(pub u64) {
+        offset: u32 = 0..30;
+        l2idx: u16 = 30..39;
+        l1idx: u16 = 39..48;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // This test is useful for making sense of early-stage exceptions.  Qemu
+    // will report an exception of the form below.  Copy the ESR value into
+    // this test to break it down.
+    //
+    // Exception return from AArch64 EL2 to AArch64 EL1 PC 0x8006c
+    // Taking exception 3 [Prefetch Abort] on CPU 0
+    // ...from EL1 to EL1
+    // ...with ESR 0x21/0x86000004
+    // ...with FAR 0x80090
+    // ...with ELR 0x80090
+    // ...to EL1 PC 0x200 PSTATE 0x3c5
+    #[test]
+    fn test_parse_esr_el1() {
+        let r = EsrEl1(0x86000004);
+        assert_eq!(r.exception_class().unwrap(), ExceptionClass::InstructionAbortSameEl);
+        assert_eq!(
+            EsrEl1IssInstructionAbort::from_esr_el1(r).unwrap().instruction_fault().unwrap(),
+            InstructionFaultStatusCode::TranslationFaultLevel0
+        );
+    }
+
+    #[test]
+    fn breakdown_vadder() {
+        let va = Vaddr4K4K(0xffff_8000_0000_0000);
+        assert_eq!(va.l1idx(), 256);
+        assert_eq!(va.l2idx(), 0);
+        assert_eq!(va.l3idx(), 0);
+        assert_eq!(va.l4idx(), 0);
+        assert_eq!(va.offset(), 0);
+
+        let va = Vaddr4K4K(0x0000_0000_0008_00a8);
+        assert_eq!(va.l1idx(), 0);
+        assert_eq!(va.l2idx(), 0);
+        assert_eq!(va.l3idx(), 0);
+        assert_eq!(va.l4idx(), 128);
+        assert_eq!(va.offset(), 168);
+
+        let va = Vaddr4K1G(0xffff_8000_0000_0000);
+        assert_eq!(va.l1idx(), 256);
+        assert_eq!(va.l2idx(), 0);
+        assert_eq!(va.offset(), 0);
+
+        let va = Vaddr4K1G(0x0000_0000_0008_00a8);
+        assert_eq!(va.l1idx(), 0);
+        assert_eq!(va.l2idx(), 0);
+        assert_eq!(va.offset(), 524456);
+
+        let va = Vaddr4K1G(0xffff_8000_0010_00c8);
+        assert_eq!(va.l1idx(), 256);
+        assert_eq!(va.l2idx(), 0);
+        assert_eq!(va.offset(), 0x1000c8);
+    }
 }

--- a/lib/aarch64-unknown-none-elf.json
+++ b/lib/aarch64-unknown-none-elf.json
@@ -9,7 +9,7 @@
 	"llvm-target": "aarch64-unknown-none",
 	"max-atomic-width": 128,
 	"panic-strategy": "abort",
-	"relocation-model": "static",
+	"relocation-model": "pie",
 	"target-pointer-width": "64",
 	"pre-link-args": {
 		"ld.lld": [

--- a/lib/riscv64-unknown-none-elf.json
+++ b/lib/riscv64-unknown-none-elf.json
@@ -13,7 +13,7 @@
 	"llvm-target": "riscv64",
 	"max-atomic-width": 64,
 	"panic-strategy": "abort",
-	"relocation-model": "static",
+	"relocation-model": "pie",
 	"target-pointer-width": "64",
 	"pre-link-args": {
 		"ld.lld": [


### PR DESCRIPTION
Before entering rust, we set up a single 2GiB page, enable the MMU and jump to the higher half. Also adds some registers and tests to help decipher any issues.